### PR TITLE
Upgrade ingress when upgrading cluster

### DIFF
--- a/upgrade-cluster.yml
+++ b/upgrade-cluster.yml
@@ -162,6 +162,14 @@
     - { role: kubernetes-apps, tags: apps }
   environment: "{{ proxy_env }}"
 
+- name: Upgrade ingress controller on controller nodes
+  hosts: kube-master
+  gather_facts: False
+  any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
+  roles:
+    - { role: kubespray-defaults }
+    - { role: kubernetes-apps/ingress_controller, tags: ingress-controller }
+
 - hosts: k8s-cluster
   gather_facts: False
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"


### PR DESCRIPTION
As pointed out in code review of the modio internal branch, this might be a better change in kubespray.


See:  https://gitlab.com/ModioAB/sysadmin/-/merge_requests/730#note_608069256